### PR TITLE
Fix bug with "hit " and "miss" missing from nginx logs

### DIFF
--- a/overlay/hooks/supervisord-pre.d/90-nginx_config.sh
+++ b/overlay/hooks/supervisord-pre.d/90-nginx_config.sh
@@ -10,7 +10,7 @@ mkdir -p /var/log/nginx
 
 
 # Change nginx settings to point to the stdout log locations
-sed -i -e "s|access_log .*$|error_log /var/log/nginx/access.log;|"  /etc/nginx/sites-available/10_generic.conf;
+sed -i -e "s|access_log .*$|access_log /var/log/nginx/access.log  cachelog;|"  /etc/nginx/sites-available/10_generic.conf;
 sed -i -e "s|error_log .*$|error_log /var/log/nginx/error.log;|"  /etc/nginx/sites-available/10_generic.conf;
 
 


### PR DESCRIPTION
update fork from the original repo